### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.1.5
+  - 2.2.0
 bundler_args: "--without development production --deployment --jobs=3 --retry=3"
 cache: :bundler
 before_script:


### PR DESCRIPTION
This should significantly cut down on the time it takes for CI to finish because it shouldn't need to rebundle cause it caches unless you add new gems or hit some other specific criteria.
